### PR TITLE
remove colon from titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Create a report about something that is not working
 labels: ["bug"]
-title: "[Bug]: "
+title: "[Bug] "
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/20_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/20_feature_request.yml
@@ -1,7 +1,7 @@
 name: ✨Feature Request
 description: Request a new feature or enhancement
 labels: ["feature"]
-title: "[Feature]: "
+title: "[Feature] "
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Description

Remove colon from title templates, so that it does not look awkward when we have to add colons for categorizing the feature for subcomponents. 

## Changes Made

* Remove colon from title in bug template
* Remove colon from title in feature template

## Related Issues

N/A

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a dedicated VM or a customer VM [name of the VM]
- [ ] I have added appropriate documentation or updated existing documentation.
